### PR TITLE
Make badges route to https

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -207,14 +207,14 @@
                 <dt>Markdown:</dt>
                 <dd>
                 <pre>
-[![Simple Haskell](http://simplehaskell.org/badges/badge.svg)](http://simplehaskell.org)
+[![Simple Haskell](https://www.simplehaskell.org/badges/badge.svg)](https://www.simplehaskell.org)
                 </pre>
                 </dd>
 
                 <dt>HTML:</dt>
                 <dd>
                 <pre>
-&lt;a href="http://simplehaskell.org"&gt;&lt;img src="http://simplehaskell.org/badges/badge.svg" /&gt;&lt;/a&gt;
+&lt;a href="https://www.simplehaskell.org"&gt;&lt;img src="https://www.simplehaskell.org/badges/badge.svg" /&gt;&lt;/a&gt;
                 </pre>
                 </dd>
                 </dl>


### PR DESCRIPTION
When a current badge:
```
<a href="http://simplehaskell.org"><img src="http://simplehaskell.org/badges/badge.svg" /></a>
```
is added to my webpage (which uses letsencrypt as CA for ensuring https) and the page is reloaded in Firefox, Firefox says my connection is no longer secure https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox?redirectlocale=en-US&as=u&redirectslug=how-does-content-isnt-secure-affect-my-safety&utm_source=inproduct saying:
```
Parts of the page are not secure (such as images).
```

Why not default to https for "badge.svg"